### PR TITLE
Be specific about whose history is whose

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -16,9 +16,10 @@ class Game
   end
 
   def play_round
-    player1_choice = Player.players[@player1].call(history.dup)
-    player2_choice = Player.players[@player2].call(history.dup)
-    history << { player1 => player1_choice, player2 => player2_choice }
+    player1_choice = Player.players[@player1].call(player1_history.dup)
+    player2_choice = Player.players[@player2].call(player2_history.dup)
+    player1_history << { own: player1_choice, other: player2_choice }
+    player2_history << { other: player1_choice, own:  player2_choice }
 
     case [player1_choice, player2_choice]
     when [:share, :share]
@@ -33,7 +34,11 @@ class Game
     end
   end
 
-  def history
-    @history ||= []
+  def player1_history
+    @player1_history ||= []
+  end
+
+  def player2_history
+    @player2_history ||= []
   end
 end

--- a/players/andrew.rb
+++ b/players/andrew.rb
@@ -2,7 +2,7 @@
 
 Player.register("Andrew Rodger") do |games|
   opposition_choices = games.map do |game|
-    game.reject{ |k,v| k ==  "Andrew Rodger" }.values.first
+    game.reject{ |k,v| k ==  :own}.values.first
   end
   if opposition_choices.select{ _1 == :share }.length > opposition_choices.select{ _1 == :steal }.length
     :steal

--- a/players/dancorne.rb
+++ b/players/dancorne.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Player.register("dancorne") do |history|
-  history.empty? ? :share : history.last.reject { |k, v| k == "dancorne" }.values.last
+  history.empty? ? :share : history.last[:other]
 end

--- a/players/katie_j.rb
+++ b/players/katie_j.rb
@@ -6,7 +6,7 @@ Player.register("Katie J") do |history|
   history.each do |game|
     game.each do |key, value|
       other_player_name = key
-      if key != "Katie J"
+      if key != :own
         other_player_moves << value
       else
         my_moves << value

--- a/players/simon.rb
+++ b/players/simon.rb
@@ -4,9 +4,9 @@ Player.register("simon") do |history|
   my_moves = []
   their_moves = []
   history.each do |move|
-    move.transform_keys(&:to_sym) => { simon: my_move, **their_move }
+    move.transform_keys(&:to_sym) => { own: my_move, other: their_move }
     my_moves << my_move
-    their_moves << their_move.values.first
+    their_moves << their_move
   end
   my_most_common_move = my_moves.max_by { |move| my_moves.count(move) }
   their_most_common_move = their_moves.max_by { |move| their_moves.count(move) }

--- a/players/whatapalaver.rb
+++ b/players/whatapalaver.rb
@@ -5,6 +5,6 @@ Player.register("whatapalaver") do |history|
   if history.empty?
     loaded_options.sample
   else
-    history.last.reject { |name, _move| name == "whatapalaver" }.values.last == :steal ? :steal : loaded_options.sample
+    history.last.reject { |name, _move| name == :own }.values.last == :steal ? :steal : loaded_options.sample
   end
 end

--- a/spec/contests_spec.rb
+++ b/spec/contests_spec.rb
@@ -21,10 +21,10 @@ describe "players" do
       it "can make a turn for #{player}" do
         1000.times do
           history = [
-            { player => :share, "greg" => :share },
-            { player => :steal, "greg" => :steal },
-            { player => :share, "greg" => :steal },
-            { player => :steal, "greg" => :share }
+            { own: :share, other: :share },
+            { own: :steal, other: :steal },
+            { own: :share, other: :steal },
+            { own: :steal, other: :share }
           ].shuffle
           expect(Player.players[player].call(history)).to be_truthy
         end

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -17,7 +17,8 @@ describe Game do
 
       expect(game.player1_score).to eq(0)
       expect(game.player2_score).to eq(3000)
-      expect(game.history).to eq([{ "a" => :share, "b" => :steal }] * 1000)
+      expect(game.player1_history).to eq([{ :own => :share, :other => :steal }] * 1000)
+      expect(game.player2_history).to eq([{ :other => :share, :own => :steal }] * 1000)
     end
   end
 end


### PR DESCRIPTION
This line doesn't store two moves properly when player1 == player2, the player2 choice would overwrite the player1 value:
```
history << { player1 => player1_choice, player2 => player2_choice }
```

To fix that, we create a history per player to be clear who makes what moves and pass that into the appropriate player's move.

This is a breaking change, but I don't think there's a way to resolve this behaviour without breaking things unfortunately.
